### PR TITLE
fix missing --debug-brk command when trying to debug nodejs with insp…

### DIFF
--- a/src/nodeDebugAdapter.ts
+++ b/src/nodeDebugAdapter.ts
@@ -137,7 +137,7 @@ export class NodeDebugAdapter extends ChromeDebugAdapter {
                 launchArgs.push(`--inspect=${port}`);
 
                 // Always stop on entry to set breakpoints
-                launchArgs.push('--debug-brk');
+                launchArgs.push('--inspect-brk');
             }
 
             this._continueAfterConfigDone = !args.stopOnEntry;


### PR DESCRIPTION
fix missing --debug-brk command when trying to debug nodejs with inspector.

related to:
https://github.com/nodejs/node/pull/12197
and
https://github.com/nodejs/node/issues/12360#issuecomment-293550803