### PR TITLE
Add a launch.json option to open a websocket that exposes a connection to the CRDP server

### DIFF
--- a/src/nodeDebugAdapter.ts
+++ b/src/nodeDebugAdapter.ts
@@ -177,7 +177,7 @@ export class NodeDebugAdapter extends ChromeDebugAdapter {
                 .then(() => {
                     return args.noDebug ?
                         Promise.resolve() :
-                        this.doAttach(port, undefined, args.address, args.timeout);
+                        this.doAttach(port, undefined, args.address, args.timeout, undefined, args.extraCRDPChannelPort);
                 });
         });
     }
@@ -214,8 +214,8 @@ export class NodeDebugAdapter extends ChromeDebugAdapter {
         });
     }
 
-    protected async doAttach(port: number, targetUrl?: string, address?: string, timeout?: number): Promise<any> {
-        await super.doAttach(port, targetUrl, address, timeout);
+    protected async doAttach(port: number, targetUrl?: string, address?: string, timeout?: number, websocketUrl?: string, extraCRDPChannelPort?: number): Promise<any> {
+        await super.doAttach(port, targetUrl, address, timeout, websocketUrl, extraCRDPChannelPort);
         this.beginWaitingForDebuggerPaused();
         this.getNodeProcessDetailsIfNeeded();
 

--- a/src/nodeDebugInterfaces.d.ts
+++ b/src/nodeDebugInterfaces.d.ts
@@ -42,9 +42,6 @@ export interface ILaunchRequestArguments extends Core.ILaunchRequestArgs, ICommo
     /** Logging options */
     diagnosticLogging?: boolean;
     verboseDiagnosticLogging?: boolean;
-
-    /** Private undocumented property to multiplex the CRDP connection into an additional channel */
-    extraCRDPChannelPort?: number;
 }
 
 /**

--- a/src/nodeDebugInterfaces.d.ts
+++ b/src/nodeDebugInterfaces.d.ts
@@ -42,6 +42,9 @@ export interface ILaunchRequestArguments extends Core.ILaunchRequestArgs, ICommo
     /** Logging options */
     diagnosticLogging?: boolean;
     verboseDiagnosticLogging?: boolean;
+
+    /** Private undocumented property to multiplex the CRDP connection into an additional channel */
+    extraCRDPChannelPort?: number;
 }
 
 /**


### PR DESCRIPTION
Add a launch.json option to open a websocket that exposes a connection to the CRDP server

This will use the feature added in this PR: https://github.com/Microsoft/vscode-chrome-debug-core/pull/214