### PR TITLE
Add a launch.json option to capture output from stdoutput and stderr streams

### DIFF
--- a/package.json
+++ b/package.json
@@ -339,6 +339,14 @@
                 "type": "boolean",
                 "description": "%node.showAsyncStacks.description%",
                 "default": true
+              },
+              "outputCapture": {
+                "enum": [
+                  "console",
+                  "std"
+                ],
+                "description": "%node.launch.outputCapture.description%",
+                "default": "console"
               }
             }
           },

--- a/package.nls.json
+++ b/package.nls.json
@@ -31,6 +31,7 @@
 	"node.launch.runtimeArgs.description": "Optional arguments passed to the runtime executable.",
 	"node.launch.env.description": "Environment variables passed to the program.",
 	"node.launch.envFile.description": "Absolute path to a file containing environment variable definitions.",
+	"node.launch.outputCapture.description": "Where to capture output messages: Console API, or stdout/stderr streams.",
 
 	"node.launch.config.name": "Launch",
 

--- a/src/nodeDebugInterfaces.d.ts
+++ b/src/nodeDebugInterfaces.d.ts
@@ -7,6 +7,8 @@ import * as Core from 'vscode-chrome-debug-core';
 
 type ConsoleType = "internalConsole" | "integratedTerminal" | "externalTerminal";
 
+type OutputCaptureType = "console" | "std";
+
 export interface ICommonRequestArgs extends Core.ICommonRequestArgs {
     stopOnEntry?: boolean;
     address?: string;
@@ -38,6 +40,8 @@ export interface ILaunchRequestArguments extends Core.ILaunchRequestArgs, ICommo
     console?: ConsoleType;
     /** Manually selected debugging port */
     port?: number;
+    /** Source of the debug output */
+    outputCapture?: OutputCaptureType;
 
     /** Logging options */
     diagnosticLogging?: boolean;


### PR DESCRIPTION
This will help with Microsoft/vscode#19750.
We'll just set `"outputCapture": "std",` in the launch.json file.
```js
...
  "configurations": [{
    "name": "Debug Jasmine",
    "type": "node",
    ...
    "debugCapture": "std",
    ...
  }
...
```

This approach is more lightweight than the original proposed `"console": "internalConsole"` approach, which starts a separate shell process with (e.g. on my PC zsh with lots of plugins is started).