### PR TITLE
Add version to all telemetry events, and properly trigger start-up telemetry

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -53,7 +53,7 @@
 				"--grep", ".*" ],
 			"cwd": "${workspaceFolder}",
 			"skipFiles": [
-                "<node_internals>/**/*.js"
+				"<node_internals>/**/*.js"
 			],
 			"sourceMaps": true,
 			"outFiles": ["${workspaceFolder}/out/**/*.js"]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -59,6 +59,15 @@
 				"transifex-push-test"
 			],
 			"internalConsoleOptions": "openOnSessionStart"
-		}
+		},
+        {
+            "name": "attach node-debug",
+            "type": "node",
+            "request": "attach",
+            "protocol": "inspector",
+            "port": 1235,
+            "outFiles": ["${workspaceFolder}/out/**/*.js"],
+            "internalConsoleOptions": "openOnSessionStart",
+        }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -38,6 +38,27 @@
 			"internalConsoleOptions": "openOnSessionStart"
 		},
         {
+            "name": "Grepped Tests",
+            "type": "node",
+            "request": "launch",
+            "protocol": "inspector",
+            "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+			"args": [ "--no-timeouts",
+				"-s", "2000",
+				"--colors",
+				"--reporter", "node_modules/vscode-chrome-debug-core-testsupport/out/loggingReporter.js",
+				"./out/test",
+				"-u", "tdd",
+                "-R", "node_modules/vscode-chrome-debug-core-testsupport/out/loggingReporter.js",
+				"--grep", ".*" ],
+            "cwd": "${workspaceFolder}",
+            "skipFiles": [
+                "<node_internals>/**/*.js"
+            ],
+			"sourceMaps": true,
+            "outFiles": ["${workspaceFolder}/out/**/*.js"]
+        },
+        {
 			"name": "Run Extension",
 			"type": "extensionHost",
 			"request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -38,11 +38,11 @@
 			"internalConsoleOptions": "openOnSessionStart"
 		},
         {
-            "name": "Grepped Tests",
-            "type": "node",
-            "request": "launch",
-            "protocol": "inspector",
-            "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+			"name": "Grepped Tests",
+			"type": "node",
+			"request": "launch",
+			"protocol": "inspector",
+			"program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
 			"args": [ "--no-timeouts",
 				"-s", "2000",
 				"--colors",
@@ -51,12 +51,12 @@
 				"-u", "tdd",
                 "-R", "node_modules/vscode-chrome-debug-core-testsupport/out/loggingReporter.js",
 				"--grep", ".*" ],
-            "cwd": "${workspaceFolder}",
-            "skipFiles": [
+			"cwd": "${workspaceFolder}",
+			"skipFiles": [
                 "<node_internals>/**/*.js"
-            ],
+			],
 			"sourceMaps": true,
-            "outFiles": ["${workspaceFolder}/out/**/*.js"]
+			"outFiles": ["${workspaceFolder}/out/**/*.js"]
         },
         {
 			"name": "Run Extension",

--- a/src/nodeDebug.ts
+++ b/src/nodeDebug.ts
@@ -2,7 +2,7 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-import {ChromeDebugSession, logger} from 'vscode-chrome-debug-core';
+import {ChromeDebugSession, logger, telemetry} from 'vscode-chrome-debug-core';
 import * as path from 'path';
 import * as os from 'os';
 
@@ -17,4 +17,6 @@ ChromeDebugSession.run(ChromeDebugSession.getSession(
     }));
 
 /* tslint:disable:no-var-requires */
-logger.log('node-debug2: ' + require('../../package.json').version);
+const debugAdapterVersion = require('../../package.json').version;
+logger.log('node-debug2: ' + debugAdapterVersion);
+telemetry.telemetry.addCustomGlobalProperty({"Versions.DebugAdapter": debugAdapterVersion});

--- a/src/nodeDebugAdapter.ts
+++ b/src/nodeDebugAdapter.ts
@@ -460,8 +460,7 @@ export class NodeDebugAdapter extends ChromeDebugAdapter {
     public async configurationDone(): Promise<void> {
         if (!this.chrome) {
             // It's possible to get this request after we've detached, see #21973
-            await super.configurationDone();
-            return;
+            return super.configurationDone();
         }
 
         // This message means that all breakpoints have been set by the client. We should be paused at this point.
@@ -474,9 +473,8 @@ export class NodeDebugAdapter extends ChromeDebugAdapter {
             await this.onPaused(this._entryPauseEvent);
         }
 
-        await super.configurationDone();
-
         this.events.emit(ChromeDebugSession.FinishedStartingUpEventName);
+        await super.configurationDone();
     }
 
     private killNodeProcess(): void {


### PR DESCRIPTION
We report the node version and Versions.DebugAdapter as a common telemetry property
We also trigger ChromeDebugSession.FinishedStartingUpEventName to properly mark the end of startup and trigger the end of the report-start-up-timings telemetry event