### PR TITLE
Simplify EH-debugging when running VS Code out of source

### DIFF
--- a/src/nodeDebugAdapter.ts
+++ b/src/nodeDebugAdapter.ts
@@ -240,6 +240,18 @@ export class NodeDebugAdapter extends ChromeDebugAdapter {
 
         const runtimeArgs = args.runtimeArgs || [];
         const programArgs = args.args || [];
+
+        // if VS Code runs out of source, add the path to the VS Code workspace as a first argument so that Electron turns into VS Code
+        const ix = args.runtimeExecutable.indexOf(process.platform === 'win32' ? '\\.build\\electron\\' : '/.build/electron/');
+        if (ix > 0 && programArgs.length > 0) {
+            // guess the VS Code workspace path
+            const vscode_workspace_path = args.runtimeExecutable.substr(0, ix);
+            // only add path if user hasn't already added path
+            if (!programArgs[0].startsWith(vscode_workspace_path)) {
+                programArgs.unshift(vscode_workspace_path);
+            }
+        }
+
         launchArgs = launchArgs.concat(runtimeArgs, programArgs);
 
         const envArgs = this.collectEnvFileArgs(args) || args.env;


### PR DESCRIPTION
If VS Code runs out of source, debugging an extension fails because Electron runs as a generic app instead of VS Code.

The (undocumented) fix is to add the path of the VS Code workspace as the first argument to the launch configuration, e.g.:
```js
        {
            "name": "Extension",
            "type": "extensionHost",
            "request": "launch",
            "runtimeExecutable": "${execPath}",
            "args": [
                        "/Users/JohnDoe/src/vscode",
                        "--extensionDevelopmentPath=${workspaceFolder}"
            ],
            "outFiles": [ "${workspaceFolder}/out/**/*.js" ],
            "preLaunchTask": "npm: watch"
        },
```

This PR modifies node-debug2 to automatically add the path to the VS Code workspace as the first argument to the argument list (iff the user hasn't done that already).


see https://github.com/Microsoft/vscode/issues/47705#issuecomment-380744178 for details