### PR TITLE
Add optional parameter to package command to specify the package name

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -142,7 +142,11 @@ gulp.task('vsce-publish', function () {
     return vsce.publish();
 });
 gulp.task('vsce-package', function () {
-    return vsce.createVSIX();
+    const usePackagePathOptionIndex = process.argv.findIndex(arg => arg === "--packagePath");
+    const options = (usePackagePathOptionIndex >= 0 && usePackagePathOptionIndex < process.argv.length)
+        ? { packagePath: process.argv[usePackagePathOptionIndex + 1] }
+        : {};
+    return vsce.createVSIX(options);
 });
 
 gulp.task('publish', function(callback) {


### PR DESCRIPTION
We'll use this command in our build system. Generating a .vsix with the same name always makes it easier to configure the build system. We'll use "npm run package -- --packagePath node-debug2.vsix"