### PR TITLE
update to the latest core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -333,9 +333,9 @@
       "dev": true
     },
     "async-limiter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
     "async-settle": {
       "version": "1.0.0",
@@ -752,9 +752,9 @@
       }
     },
     "color": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/color/-/color-3.1.1.tgz",
-      "integrity": "sha512-PvUltIXRjehRKPSy89VnDWFKY58xyhTLyxIg21vwQBI6qLwZNPmC8k3C1uytIgFKEpOIzN4y32iPm8231zFHIg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
+      "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
       "requires": {
         "color-convert": "^1.9.1",
         "color-string": "^1.5.2"
@@ -6433,9 +6433,9 @@
       }
     },
     "vscode-chrome-debug-core": {
-      "version": "6.7.48",
-      "resolved": "https://registry.npmjs.org/vscode-chrome-debug-core/-/vscode-chrome-debug-core-6.7.48.tgz",
-      "integrity": "sha512-BCf8NiZCJrccPx7kXO7j6R3erZ+2UnayXVx7nH3WPwl7ukGm17OT0zYh+LEImHI2GlULWzjIo3abUScjhb30Ig==",
+      "version": "6.7.53",
+      "resolved": "https://registry.npmjs.org/vscode-chrome-debug-core/-/vscode-chrome-debug-core-6.7.53.tgz",
+      "integrity": "sha512-R4DW7rCK/7CmBUVy99XzVx0uaI7zh8SDgnn1YoD5Xx0pRAhdgM8zcaELbQB4Qm+oBAln8TM41sUnVV9YIGIQCQ==",
       "requires": {
         "@types/source-map": "^0.1.27",
         "color": "^3.0.0",
@@ -6446,13 +6446,14 @@
         "vscode-debugadapter": "^1.34.0",
         "vscode-debugprotocol": "^1.34.0",
         "vscode-nls": "^4.0.0",
+        "vscode-uri": "^2.0.2",
         "ws": "^6.0.0"
       },
       "dependencies": {
         "glob": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -6468,18 +6469,18 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "vscode-debugadapter": {
-          "version": "1.34.0",
-          "resolved": "https://registry.npmjs.org/vscode-debugadapter/-/vscode-debugadapter-1.34.0.tgz",
-          "integrity": "sha512-ye11QX9K4QA4TOuJHVusJenTuqh7GrCsLZJ7Gs86spOJ4WTTPd8wFLJBjL5ivkCUln/Tyo4HMkxlLBlTBtHdog==",
+          "version": "1.35.0",
+          "resolved": "https://registry.npmjs.org/vscode-debugadapter/-/vscode-debugadapter-1.35.0.tgz",
+          "integrity": "sha512-Au90Iowj6TuD5uDMaTnxOjl/9hQN0Yoky1TV1Cjjr7jPdxTQpALBRW09Y2LzkIXUVICXlAqxWL9zL8BpzI30jg==",
           "requires": {
             "mkdirp": "^0.5.1",
-            "vscode-debugprotocol": "1.34.0"
+            "vscode-debugprotocol": "1.35.0"
           }
         },
         "vscode-debugprotocol": {
-          "version": "1.34.0",
-          "resolved": "https://registry.npmjs.org/vscode-debugprotocol/-/vscode-debugprotocol-1.34.0.tgz",
-          "integrity": "sha512-tcMThtgk9TUtE8zzAIwPvHZfgnEYnVa7cI3YaQk/o54Q9cme+TLd/ao60a6ycj5rCrI/B5r/mAfeK5EKSItm7g=="
+          "version": "1.35.0",
+          "resolved": "https://registry.npmjs.org/vscode-debugprotocol/-/vscode-debugprotocol-1.35.0.tgz",
+          "integrity": "sha512-+OMm11R1bGYbpIJ5eQIkwoDGFF4GvBz3Ztl6/VM+/RNNb2Gjk2c0Ku+oMmfhlTmTlPCpgHBsH4JqVCbUYhu5bA=="
         }
       }
     },
@@ -6613,6 +6614,11 @@
           }
         }
       }
+    },
+    "vscode-uri": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-2.0.3.tgz",
+      "integrity": "sha512-4D3DI3F4uRy09WNtDGD93H9q034OHImxiIcSq664Hq1Y1AScehlP3qqZyTkX/RWxeu0MRMHGkrxYqm2qlDF/aw=="
     },
     "vso-node-api": {
       "version": "6.1.2-preview",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "vscode-chrome-debug-core": "^6.7.48",
+    "vscode-chrome-debug-core": "^6.7.53",
     "vscode-debugadapter": "^1.33.0-pre.2",
     "vscode-nls": "^4.0.0"
   },

--- a/src/nodeDebugAdapter.ts
+++ b/src/nodeDebugAdapter.ts
@@ -210,7 +210,7 @@ export class NodeDebugAdapter extends ChromeDebugAdapter {
         const wslLaunchArgs = wsl.createLaunchArg(args.useWSL, args.console === 'externalTerminal', cwd, runtimeExecutable, launchArgs, program);
         // if using subsystem for linux, we will trick the debugger to map source files
         if (args.useWSL && !args.localRoot && !args.remoteRoot) {
-            this._pathTransformer.attach(<IAttachRequestArguments>{
+            this.pathTransformer.attach(<IAttachRequestArguments>{
                 remoteRoot: wslLaunchArgs.remoteRoot,
                 localRoot: wslLaunchArgs.localRoot
             });
@@ -622,7 +622,7 @@ export class NodeDebugAdapter extends ChromeDebugAdapter {
             // programPath is the generated file or whether it is the source (and we need source mapping).
             // Typically this happens if a tool like 'babel' or 'uglify' is used (because they both transpile js to js).
             // We use the source maps to find a 'source' file for the given js file.
-            const generatedPath = await this._sourceMapTransformer.getGeneratedPathFromAuthoredPath(programPath);
+            const generatedPath = await this.sourceMapTransformer.getGeneratedPathFromAuthoredPath(programPath);
             if (generatedPath && generatedPath !== programPath) {
                 // programPath must be source because there seems to be a generated file for it
                 logger.log(`Launch: program '${programPath}' seems to be the source; launch the generated file '${generatedPath}' instead`);
@@ -638,7 +638,7 @@ export class NodeDebugAdapter extends ChromeDebugAdapter {
                 return Promise.reject<string>(errors.cannotLaunchBecauseSourceMaps(programPath));
             }
 
-            const generatedPath = await this._sourceMapTransformer.getGeneratedPathFromAuthoredPath(programPath);
+            const generatedPath = await this.sourceMapTransformer.getGeneratedPathFromAuthoredPath(programPath);
             if (!generatedPath) { // cannot find generated file
                 if (this._launchAttachArgs.outFiles || this._launchAttachArgs.outDir) {
                     return Promise.reject<string>(errors.cannotLaunchBecauseJsNotFound(programPath));
@@ -875,7 +875,7 @@ export class NodeDebugAdapter extends ChromeDebugAdapter {
     /**
      * If realPath is an absolute path or a URL, return realPath. Otherwise, prepend the node_internals marker
      */
-    protected realPathToDisplayPath(realPath: string): string {
+    public realPathToDisplayPath(realPath: string): string {
         if (!realPath.match(/VM\d+/) && !path.isAbsolute(realPath)) {
             return `${NodeDebugAdapter.NODE_INTERNALS}/${realPath}`;
         }
@@ -886,7 +886,7 @@ export class NodeDebugAdapter extends ChromeDebugAdapter {
     /**
      * If displayPath starts with the NODE_INTERNALS indicator, strip it.
      */
-    protected displayPathToRealPath(displayPath: string): string {
+    public displayPathToRealPath(displayPath: string): string {
         const match = displayPath.match(new RegExp(`^${NodeDebugAdapter.NODE_INTERNALS}[\\\\/](.*)`));
         return match ? match[1] : super.displayPathToRealPath(displayPath);
     }


### PR DESCRIPTION
@roblourens Could you double check that the args removed in `terminateSession` and `getReadonlyOrigin` are truly not used anywhere? I couldn't find a single caller that passed them.