### PR TITLE
feat: accept patterns sent by node-debug module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,12 @@
         "through2": "^2.0.3"
       }
     },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+      "dev": true
+    },
     "@types/mocha": {
       "version": "2.2.47",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.47.tgz",
@@ -1679,7 +1685,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1700,12 +1707,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1720,17 +1729,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1847,7 +1859,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1859,6 +1872,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1873,6 +1887,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1880,12 +1895,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1904,6 +1921,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1984,7 +2002,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1996,6 +2015,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2081,7 +2101,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2117,6 +2138,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2136,6 +2158,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2179,12 +2202,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -14,11 +14,13 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
+    "minimatch": "^3.0.4",
     "vscode-chrome-debug-core": "^6.8.2",
     "vscode-debugadapter": "^1.37.1",
     "vscode-nls": "^4.0.0"
   },
   "devDependencies": {
+    "@types/minimatch": "^3.0.3",
     "@types/mocha": "^2.2.47",
     "@types/node": "^8.0.58",
     "del": "^2.2.2",

--- a/src/nodeBreakpoints.ts
+++ b/src/nodeBreakpoints.ts
@@ -4,7 +4,6 @@
 
 import { Breakpoints, chromeConnection, InternalSourceBreakpoint, ISetBreakpointResult, ISetBreakpointsArgs, logger, ScriptContainer } from 'vscode-chrome-debug-core';
 import { NodeDebugAdapter } from './nodeDebugAdapter';
-import * as utils from './utils';
 
 export class NodeBreakpoints extends Breakpoints {
     constructor(private nodeDebugAdapter: NodeDebugAdapter, chromeConnection: chromeConnection.ChromeConnection) {

--- a/src/nodeBreakpoints.ts
+++ b/src/nodeBreakpoints.ts
@@ -49,7 +49,7 @@ export class NodeBreakpoints extends Breakpoints {
 
     protected validateBreakpointsPath(args: ISetBreakpointsArgs): Promise<void> {
         return super.validateBreakpointsPath(args).catch(e => {
-            if (!this.nodeDebugAdapter.launchAttachArgs.disableOptimisticBPs && args.source.path && utils.isJavaScript(args.source.path)) {
+            if (!this.nodeDebugAdapter.launchAttachArgs.disableOptimisticBPs && args.source.path && this.nodeDebugAdapter.jsDeterminant.isJavaScript(args.source.path)) {
                 return undefined;
             } else {
                 return Promise.reject(e);

--- a/src/nodeDebugInterfaces.d.ts
+++ b/src/nodeDebugInterfaces.d.ts
@@ -58,6 +58,9 @@ export interface ILaunchRequestArguments extends Core.ILaunchRequestArgs, ICommo
 
     // When node version is detected by node-debug
     __nodeVersion?: string;
+
+    // A list of glob patterns that can be debugged by the extension.
+    __debuggablePatterns: string[];
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -37,7 +37,7 @@ export class JavaScriptDeterminant {
             fs.readSync(fd, buffer, 0, buffer.length, 0);
             fs.closeSync(fd);
             const line = buffer.toString();
-            return NODE_SHEBANG_MATCHER.test(line)
+            return NODE_SHEBANG_MATCHER.test(line);
         } catch (e) {
             return false;
         }


### PR DESCRIPTION
Goes with and depends on https://github.com/microsoft/vscode-node-debug/pull/197.

It accepts the matches sent down from vscode-node-debug. Unfortunately we
don't have access to the exact matching logic that vs code uses internally for
file patterns. Here I've put in minimatch which seems to get my common test
cases, but this isn't perfect.

Perhaps we want to invert this in some way? Maybe instead vscode-node-debug can
run the check and signal to this module that "yes, I've verified this is a
directly executable file, please run it." Open to ideas!