### PR TITLE
EH debugging: support path args that lack a ".js" extension

### DIFF
--- a/src/nodeDebugAdapter.ts
+++ b/src/nodeDebugAdapter.ts
@@ -285,7 +285,7 @@ export class NodeDebugAdapter extends ChromeDebugAdapter {
             if (arg.startsWith('-')) {
                 // arg is an option
                 const pair = arg.split('=', 2);
-                if (pair.length === 2 && fs.existsSync(pair[1])) {
+                if (pair.length === 2 && (fs.existsSync(pair[1]) || fs.existsSync(pair[1] + '.js')) {
                     return { prefix: pair[0] + '=', path: pair[1] };
                 }
                 return { prefix: arg };


### PR DESCRIPTION
Path arguments that lack a ".js" extension are not recognised as paths and are not properly processed in remote scenarios.

For details see https://github.com/microsoft/vscode/issues/83145#issuecomment-545962732