### PR TITLE
fix for missing bracket

### DIFF
--- a/src/nodeDebugAdapter.ts
+++ b/src/nodeDebugAdapter.ts
@@ -314,7 +314,7 @@ export class NodeDebugAdapter extends ChromeDebugAdapter {
             if (arg.startsWith('-')) {
                 // arg is an option
                 const pair = arg.split('=', 2);
-                if (pair.length === 2 && (fs.existsSync(pair[1]) || fs.existsSync(pair[1] + '.js')) {
+                if (pair.length === 2 && (fs.existsSync(pair[1]) || fs.existsSync(pair[1] + '.js'))) {
                     return { prefix: pair[0] + '=', path: pair[1] };
                 }
                 return { prefix: arg };


### PR DESCRIPTION
@dbaeumer this missing bracket was causing issues when running 
gulp translations-export
[02:36:32] Using gulpfile c:\_shift\vscode\vscode-node-debug2\gulpfile.js
[02:36:32] Starting 'translations-export'...
[02:36:32] Starting '_build'...
[02:36:32] Starting 'copy-scripts'...
[02:36:32] Finished 'copy-scripts' after 133 ms
[02:36:32] Starting '<anonymous>'...
src\nodeDebugAdapter.ts(317,101): error TS1005: ')' expected.
TypeScript: 1 syntax error
TypeScript: emit succeeded (with errors)
[02:36:40] The following tasks did not complete: translations-export, _build, <a
nonymous>
